### PR TITLE
Detect maintenance mode & restrict access to files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+## Only allow web access to 'index.php' and everything in the 'public' directory.
+
+DirectoryIndex index.php
+RewriteEngine On
+
+RewriteCond %{SCRIPT_FILENAME} !-d
+RewriteCond %{SCRIPT_FILENAME} !-f
+RewriteRule ^ index.php [L]
+
+RewriteRule !^(public/|index\.php) [NC,F]

--- a/index.php
+++ b/index.php
@@ -1,12 +1,14 @@
 <?php
 
-// TODO: Handle this dynamically in the future
-$maintenance_mode = true;
-
 // Check for maintenance mode
+$maintenance_mode = file_exists(__DIR__ . "/.maintenance");
 if ($maintenance_mode) {
     echo "This site is in Maintenance Mode." . PHP_EOL;
     exit(0);
 }
 
-// TODO: We are NOT in maintenance mode, do whatever else we need to do.
+require_once "config.php";
+
+echo "We are NOT in Maintenance Mode. Hello!" . PHP_EOL;
+
+?>

--- a/index.php
+++ b/index.php
@@ -9,6 +9,20 @@ if ($maintenance_mode) {
 
 require_once "config.php";
 
-echo "We are NOT in Maintenance Mode. Hello!" . PHP_EOL;
+// This is just a REALLY rough placeholder page
+$html = "<!DOCTYPE html><html lang='en'>
+<head>
+    <title>PastLink</title>
+    <link href='/public/theme.css' rel='stylesheet'>
+</head>
+<body>";
+
+$html .= "<p>We are NOT in Maintenance Mode. Hello!</p>";
+if (DB_HOST !== null) {
+    $html .= "<p>Configuration loaded.</p>";
+}
+
+$html .= "</body></html>";
+echo $html;
 
 ?>

--- a/public/theme.css
+++ b/public/theme.css
@@ -1,0 +1,10 @@
+/**
+ * PastLink theme
+ */
+
+body {
+    font-size: 14pt;
+    font-family: Arial, Helvetica, sans-serif;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+}


### PR DESCRIPTION
Changes:

- Maintenance mode now gets switched on automatically if there is a `.maintenance` file
- Only `index.php` and things in `public/` directory should be loadable via web
- Added a super basic `theme.css` so there is something in the public directory already